### PR TITLE
Add BLU layer on Tab key, VOL reverse, BT func

### DIFF
--- a/config/boards/shields/klein/klein.keymap
+++ b/config/boards/shields/klein/klein.keymap
@@ -48,8 +48,8 @@
         nav_layer {
 
             bindings = <
-&trans         &trans         &trans         &trans         &trans              &kp CAPSLOCK   &trans         &kp K_CUT      &kp K_COPY     &kp K_PASTE
-&kp LGUI       &kp LALT       &kp LCTRL      &kp LSHFT      &trans              &kp LEFT       &kp DOWN       &kp UP         &kp RIGHT      &bt BT_CLR
+&trans         &trans         &trans         &trans         &trans              &kp CAPSLOCK   &bt BT_CLR     &kp K_CUT      &kp K_COPY     &kp K_PASTE
+&kp LGUI       &kp LALT       &kp LCTRL      &kp LSHFT      &trans              &kp LEFT       &kp DOWN       &kp UP         &kp RIGHT      &trans
 &trans         &trans         &trans         &trans         &trans              &kp INSERT     &kp HOME       &kp PG_UP      &kp PG_DN      &kp END
 &trans         &trans         &trans         &bootloader                                       &bt BT_NXT     &kp RET        &kp BKSP       &kp DEL
             >;

--- a/config/boards/shields/klein/klein.keymap
+++ b/config/boards/shields/klein/klein.keymap
@@ -34,26 +34,26 @@
 //          |  Q  |  W  |  E   |  R   |  T   |                                           |  Y   |  U    |  I    |  O   |   P   |
 //          |  A  |  S  |  D   |  F   |  G   |                                           |  H   |  J    |  K    |  L   |   '   |
 //          |  Z  |  X  |  C   |  V   |  B   |                                           |  N   |  M    |  ,    |  .   |   /   |
-//                      | ESC  | SPC |  TAB | BOOTLOADER |                         | BOOTLOADER | RET | BKSP | DEL |
+//                      | ESC  | SPC |  TAB | BOOTLOADER |                         | Mute | RET | BKSP | DEL |
 
             bindings = <
 &kp Q          &kp W          &kp E          &kp R          &kp T               &kp Y          &kp U          &kp I          &kp O          &kp P
 &mt LGUI A     &mt LALT S     &mt LCTRL D    &mt LSHFT F    &kp G               &kp H          &mt RSHFT J    &mt RCTRL K    &mt RALT L     &mt LGUI SQT
 &kp Z          &kp X          &kp C          &kp V          &kp B               &kp N          &kp M          &kp COMMA      &kp DOT        &kp FSLH
-&lt MEDIA ESC  &lt NAV SPACE  &kp TAB        &bootloader                                       &bootloader    &lt SYM RET    &lt NUM BKSP   &lt FUN DEL
+&lt MEDIA ESC  &lt NAV SPACE  &lt BLU TAB        &bootloader                                       &kp MUTE    &lt SYM RET    &lt NUM BKSP   &lt FUN DEL
             >;
-        sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
+        sensor-bindings = <&inc_dec_kp C_VOL_DN C_VOL_UP>;
         };
 
         nav_layer {
 
             bindings = <
 &trans         &trans         &trans         &trans         &trans              &kp CAPSLOCK   &trans         &kp K_CUT      &kp K_COPY     &kp K_PASTE
-&kp LGUI       &kp LALT       &kp LCTRL      &kp LSHFT      &trans              &kp LEFT       &kp DOWN       &kp UP         &kp RIGHT      &trans
+&kp LGUI       &kp LALT       &kp LCTRL      &kp LSHFT      &trans              &kp LEFT       &kp DOWN       &kp UP         &kp RIGHT      &bt BT_CLR
 &trans         &trans         &trans         &trans         &trans              &kp INSERT     &kp HOME       &kp PG_UP      &kp PG_DN      &kp END
-&trans         &trans         &trans         &bootloader                                       &bootloader    &kp RET        &kp BKSP       &kp DEL
+&trans         &trans         &trans         &bootloader                                       &bt BT_NXT     &kp RET        &kp BKSP       &kp DEL
             >;
-        sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
+        sensor-bindings = <&inc_dec_kp C_VOL_DN C_VOL_UP>;
         };
 
         num_layer {
@@ -64,7 +64,7 @@
 &kp GRAVE      &kp N1         &kp N2         &kp N3         &kp BSLH            &trans         &trans         &trans         &trans         &trans
 &kp PERIOD     &kp N0         &kp MINUS      &bootloader                                       &bootloader    &trans         &trans         &trans
             >;
-        sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
+        sensor-bindings = <&inc_dec_kp C_VOL_DN C_VOL_UP>;
         };
 
         fun_layer {
@@ -75,7 +75,7 @@
 &kp F10        &kp F1         &kp F2         &kp F3         &kp PAUSE_BREAK     &trans         &trans         &trans         &trans         &trans
 &kp ESC        &kp SPACE      &kp TAB        &bootloader                                       &bootloader    &trans         &trans         &trans
             >;
-        sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
+        sensor-bindings = <&inc_dec_kp C_VOL_DN C_VOL_UP>;
         };
 
         sym_layer {
@@ -86,7 +86,7 @@
 &kp LS(GRAVE)  &kp LS(N1)     &kp LS(N2)     &kp LS(N3)     &kp LS(BSLH)        &trans         &trans         &trans         &trans         &trans
 &kp LS(PERIOD) &kp LS(N0)     &kp LS(MINUS)  &bootloader                                       &bootloader    &trans         &trans         &trans
             >;
-        sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
+        sensor-bindings = <&inc_dec_kp C_VOL_DN C_VOL_UP>;
         };
 
         media_layer {
@@ -97,7 +97,7 @@
 &trans         &trans         &trans         &trans         &trans              &trans         &trans         &trans         &trans         &trans
 &trans         &trans         &trans         &bootloader                                       &bootloader    &kp K_STOP2    &kp K_PP       &kp K_MUTE
             >;
-        sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
+        sensor-bindings = <&inc_dec_kp C_VOL_DN C_VOL_UP>;
         };
 
         blu_layer {
@@ -108,7 +108,7 @@
 &trans         &bt BT_SEL 0   &bt BT_SEL 1   &bt BT_SEL 2   &trans              &trans         &trans         &trans         &trans         &trans
 &trans         &trans         &trans         &trans         &trans                             &trans         &trans         &trans         &trans
             >;
-        sensor-bindings = <&inc_dec_kp C_VOL_UP C_VOL_DN>;
+        sensor-bindings = <&inc_dec_kp C_VOL_DN C_VOL_UP>;
         };
     };
 };

--- a/config/boards/shields/klein/klein.keymap
+++ b/config/boards/shields/klein/klein.keymap
@@ -40,7 +40,7 @@
 &kp Q          &kp W          &kp E          &kp R          &kp T               &kp Y          &kp U          &kp I          &kp O          &kp P
 &mt LGUI A     &mt LALT S     &mt LCTRL D    &mt LSHFT F    &kp G               &kp H          &mt RSHFT J    &mt RCTRL K    &mt RALT L     &mt LGUI SQT
 &kp Z          &kp X          &kp C          &kp V          &kp B               &kp N          &kp M          &kp COMMA      &kp DOT        &kp FSLH
-&lt MEDIA ESC  &lt NAV SPACE  &lt BLU TAB        &bootloader                                       &kp MUTE    &lt SYM RET    &lt NUM BKSP   &lt FUN DEL
+&lt MEDIA ESC  &lt NAV SPACE  &lt BLU TAB        &bootloader                                       &kp MUTE   &lt SYM RET    &lt NUM BKSP   &lt FUN DEL
             >;
         sensor-bindings = <&inc_dec_kp C_VOL_DN C_VOL_UP>;
         };


### PR DESCRIPTION
- I've swapped C_VOL_UP/C_VOL_DN for Alps encoder on RH side. 
- Added &lt BLU TAB instead of &kp TAB.
- Added &bt BT_NXT on RH Encoder, and &bt BT_CLEAR on unused RH Pinky in NAV layer.