### PR TITLE
add link back to hardware repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Klein-zmk
-ZMK Firmware for Klein keyboard
+ZMK Firmware for Klein keyboard https://github.com/snsten/Klein


### PR DESCRIPTION
It would be nice to give people an easy link to click to get back to the Klein keyboard repo.